### PR TITLE
Fix download for firefox

### DIFF
--- a/drivers/index.js
+++ b/drivers/index.js
@@ -9,6 +9,8 @@ function downloadApp() {
 			let downnode = document.createElement("a");
 			downnode.download = 'AmusingDeviceApplication.exe';
 			downnode.href = `/drivers/app/app_${lastVer}.exe`;
+			document.body.appendChild(downnode); // Fix for firefox, the anchor has to be appended to the DOM.
 			downnode.click();
+			document.body.removeChild(downnode);
 		})
 }


### PR DESCRIPTION
To have file downloads to work in firefox the anchor needs to be appended to the DOM before its clicked, it's then removed straight after.